### PR TITLE
Hotfix/fix teleop xbox mapper params 

### DIFF
--- a/scripts/xbox_mapper.py
+++ b/scripts/xbox_mapper.py
@@ -30,6 +30,9 @@ last_y_button=time.time()
 last_joycb_device_check=time.time()
 button_msg = String()
 
+# Initialize driver node
+rospy.init_node('xbox_mapper_node', anonymous=True)
+
 # difference between xboxdrv USB driver and xpad.ko kernel module
 # 1) xboxdrv has only 11 indices
 # 2) U/D_PAD_BUTTON is the 7th axis
@@ -140,7 +143,7 @@ PREV_CMD_TIME = 0
 PREV_SEQ_NUM = 0
 
 MAX_VEL_FWD = rospy.get_param('~max_vel_drive', 2.6)
-MAX_VEL_TURN = rospy.get_param('~max_vel_turn', 9.0)
+MAX_VEL_TURN = rospy.get_param('~max_vel_turn', 7.0)
 MAX_VEL_FLIPPER = rospy.get_param('~max_vel_flipper', 1.4)
 DRIVE_THROTTLE = rospy.get_param('~default_drive_throttle', 0.15)
 FLIPPER_THROTTLE = rospy.get_param('~default_flipper_throttle', 0.6)
@@ -340,9 +343,6 @@ def joy_cb(Joy):
     
 # Main Function
 def joystick_main():
-
-    # Initialize driver node
-    rospy.init_node('xbox_mapper_node', anonymous=True)
     r = rospy.Rate(10) # 10hz
     # publish the latched button initializations
     a_button_pub.publish(a_button_msg)

--- a/scripts/xbox_mapper.py
+++ b/scripts/xbox_mapper.py
@@ -148,9 +148,11 @@ MAX_VEL_FLIPPER = rospy.get_param('~max_vel_flipper', 1.4)
 DRIVE_THROTTLE = rospy.get_param('~default_drive_throttle', 0.15)
 FLIPPER_THROTTLE = rospy.get_param('~default_flipper_throttle', 0.6)
 ADJ_THROTTLE = rospy.get_param('~adjustable_throttle', True)
+LEFT_RIGHT_TRIM = rospy.get_param('left_right_trim', -0.05)
 DRIVE_INCREMENTS = float(20) 
 FLIPPER_INCREMENTS = float(20) 
 DEADBAND = 0.2
+
 FWD_ACC_LIM = 0.2 
 TRN_ACC_LIM = 0.4 
 DPAD_ACTIVE = False
@@ -312,13 +314,17 @@ def joy_cb(Joy):
 
     # Drive Forward/Backward commands
     drive_cmd = DRIVE_THROTTLE * MAX_VEL_FWD * Joy.axes[L_STICK_V_AXES] #left joystick
-    if drive_cmd < FWD_DEADBAND and -FWD_DEADBAND < drive_cmd:
-        drive_cmd = 0 
-        
     # Turn left/right commands
     turn_cmd = (1.1-(drive_cmd/MAX_VEL_FWD)) * DRIVE_THROTTLE * MAX_VEL_TURN * Joy.axes[R_STICK_H_AXES]  #right joystick
+
+
     if turn_cmd < TURN_DEADBAND and -TURN_DEADBAND < turn_cmd:
         turn_cmd = 0
+    if drive_cmd < FWD_DEADBAND and -FWD_DEADBAND < drive_cmd:
+        drive_cmd = 0 
+    else:
+        turn_cmd = turn_cmd + LEFT_RIGHT_TRIM
+    
 
     # Flipper up/down commands
     flipper_cmd = (FLIPPER_THROTTLE * MAX_VEL_FLIPPER * Joy.axes[L_TRIG_AXES]) - (FLIPPER_THROTTLE * MAX_VEL_FLIPPER * Joy.axes[R_TRIG_AXES])


### PR DESCRIPTION
This fixes issue #2. The ros node is not being initialized before the ros params are requested so they are being ignored, and defaults are used instead.